### PR TITLE
Fix msgpack format of announce app data

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -134,11 +134,12 @@ static RNS::Bytes encodeAnnounceName(const String& name) {
     if (name.isEmpty()) return {};
     size_t len = name.length();
     if (len > 31) len = 31;
-    uint8_t buf[2 + 31];
+    uint8_t buf[3 + 31];
     buf[0] = 0x91;                     // msgpack fixarray(1)
-    buf[1] = 0xA0 | (uint8_t)len;     // msgpack fixstr(len)
-    memcpy(buf + 2, name.c_str(), len);
-    return RNS::Bytes(buf, 2 + len);
+    buf[1] = 0xC4;                     // msgpack bin 8
+    buf[2] = (uint8_t)len;             // bin len
+    memcpy(buf + 3, name.c_str(), len);
+    return RNS::Bytes(buf, 3 + len);
 }
 
 static void announceWithName() {


### PR DESCRIPTION
The Python LXMF "reference" implementation expects the 1st item in the announce app data (the display name) to be a msgpack `bin 8` instead of a `fixstr`.

This patch changes the app data format from
`["Name"]` (`b'\x91\xa4Name'`)
to
`[b"Name"]` (`b'\x91\xc4\x04Name'`)

(Python notation)