### PR TITLE
Add user config setting for auto-announce interval

### DIFF
--- a/src/config/UserConfig.cpp
+++ b/src/config/UserConfig.cpp
@@ -59,6 +59,7 @@ bool UserConfig::parseJson(const String& json) {
     _settings.audioVolume  = doc["audio_vol"] | 80;
 
     _settings.displayName = doc["display_name"] | "";
+    _settings.announceInterval = doc["announce_int"] | 5;
     _settings.devMode     = doc["dev_mode"]     | false;
 
     Serial.println("[CONFIG] Settings loaded");
@@ -101,6 +102,7 @@ String UserConfig::serializeToJson() const {
     doc["audio_vol"] = _settings.audioVolume;
 
     doc["display_name"] = _settings.displayName;
+    doc["announce_int"] = _settings.announceInterval;
     doc["dev_mode"]     = _settings.devMode;
 
     String json;

--- a/src/config/UserConfig.h
+++ b/src/config/UserConfig.h
@@ -57,6 +57,9 @@ struct UserSettings {
     // Identity
     String displayName;
 
+    // Announce
+    uint16_t announceInterval = 5; // minutes, 5-360
+
     // Developer mode — unlocks custom radio parameters
     bool devMode = false;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -114,7 +114,6 @@ bool wifiSTAStarted = false;
 bool wifiSTAConnected = false;
 unsigned long lastAutoAnnounce = 0;
 unsigned long lastStatusUpdate = 0;
-constexpr unsigned long ANNOUNCE_INTERVAL_MS = 5 * 60 * 1000;  // 5 minutes
 constexpr unsigned long STATUS_UPDATE_MS = 1000;                // 1 Hz status bar update
 unsigned long lastHeartbeat = 0;
 constexpr unsigned long HEARTBEAT_INTERVAL_MS = 5000;
@@ -902,8 +901,9 @@ void loop() {
         }
     }
 
-    // 5. Auto-announce every 5 minutes
-    if (bootComplete && millis() - lastAutoAnnounce >= ANNOUNCE_INTERVAL_MS) {
+    // 5. Auto-announce every 5-360 minutes (user configured)
+    const unsigned long announceInterval = (unsigned long)userConfig.settings().announceInterval * 60000; // m -> ms
+    if (bootComplete && millis() - lastAutoAnnounce >= announceInterval) {
         lastAutoAnnounce = millis();
         if (rns.loraInterface() && rns.loraInterface()->airtimeUtilization() > LoRaInterface::AIRTIME_THROTTLE) {
             Serial.println("[AUTO] Skipping announce: LoRa airtime > 25%");

--- a/src/ui/screens/LvSettingsScreen.cpp
+++ b/src/ui/screens/LvSettingsScreen.cpp
@@ -165,6 +165,10 @@ void LvSettingsScreen::buildItems() {
         _items.push_back(newId);
         idx++;
     }
+    _items.push_back({"Announce Interval", SettingType::INTEGER,
+        [&s]() { return s.announceInterval; }, [&s](int v) { s.announceInterval = v; },
+        [](int v) { return String(v) + "m"; }, 5, 60 * 6, 5}); // 5m - 6h
+    idx++;
     {
         SettingItem devModeItem;
         devModeItem.label = "Developer Mode";


### PR DESCRIPTION
Let the user configure the auto-announce interval between 5 minutes and 6 hours.

Not sure if *Setup*->*Device* is the rigtht place, though.