### PR TITLE
Separate audio notification settings. Audio notification for announces

### DIFF
--- a/src/audio/AudioNotify.cpp
+++ b/src/audio/AudioNotify.cpp
@@ -53,7 +53,7 @@ void AudioNotify::end() {
 }
 
 void AudioNotify::writeTone(uint16_t freq, uint16_t durationMs) {
-    if (!_enabled || !_i2sReady) return;
+    if (!_i2sReady) return;
 
     int numSamples = (AUDIO_SAMPLE_RATE * durationMs) / 1000;
     int16_t* buf = (int16_t*)ps_malloc(numSamples * sizeof(int16_t));
@@ -95,21 +95,21 @@ void AudioNotify::writeSilence(uint16_t durationMs) {
 }
 
 void AudioNotify::playMessage() {
-    if (!_enabled) return;
+    if (!_msg_enabled) return;
     writeTone(1000, 50);
     writeSilence(50);
     writeTone(1000, 50);
     writeSilence(30);
 }
 
-void AudioNotify::playAnnounce() {
-    if (!_enabled) return;
+void AudioNotify::playAnnounce(bool update) {
+    if (!_announce_enabled) return;
     writeTone(800, 30);
     writeSilence(20);
 }
 
 void AudioNotify::playError() {
-    if (!_enabled) return;
+    if (!_error_enabled) return;
     for (int i = 0; i < 3; i++) {
         writeTone(400, 100);
         if (i < 2) writeSilence(50);
@@ -118,7 +118,7 @@ void AudioNotify::playError() {
 }
 
 void AudioNotify::playBoot() {
-    if (!_enabled || !_i2sReady) return;
+    if (!_boot_enabled || !_i2sReady) return;
 
     // === RATDECK BOOT SEQUENCE ===
     // Sci-fi computer startup: sweep -> digital arpeggio -> confirmation

--- a/src/audio/AudioNotify.h
+++ b/src/audio/AudioNotify.h
@@ -9,13 +9,15 @@ public:
 
     // Notification sounds
     void playMessage();
-    void playAnnounce();
+    void playAnnounce(bool update);
     void playError();
     void playBoot();        // Sci-fi boot sequence
 
     // Settings
-    void setEnabled(bool enabled) { _enabled = enabled; }
-    bool isEnabled() const { return _enabled; }
+    void setBootEnabled(bool enabled) { _boot_enabled = enabled; }
+    void setMsgEnabled(bool enabled) { _msg_enabled = enabled; }
+    void setAnnounceEnabled(bool enabled) { _announce_enabled = enabled; }
+    void setErrorEnabled(bool enabled) { _error_enabled = enabled; }
     void setVolume(uint8_t vol) { _volume = vol; }
     uint8_t volume() const { return _volume; }
 
@@ -23,7 +25,10 @@ private:
     void writeTone(uint16_t freq, uint16_t durationMs);
     void writeSilence(uint16_t durationMs);
 
-    bool _enabled = true;
+    bool _boot_enabled = true;
+    bool _msg_enabled = true;
+    bool _error_enabled = true;
+    bool _announce_enabled = true;
     bool _i2sReady = false;
     uint8_t _volume = 80;  // 0-100
 };

--- a/src/config/UserConfig.cpp
+++ b/src/config/UserConfig.cpp
@@ -62,7 +62,10 @@ bool UserConfig::parseJson(const String& json) {
     _settings.timezoneSet        = doc["tz_set"]       | false;
     _settings.use24HourTime      = doc["time_24h"]     | false;
 
-    _settings.audioEnabled = doc["audio_on"]  | true;
+    _settings.audioBootEnabled = doc["audio_boot_on"]  | true;
+    _settings.audioMsgEnabled = doc["audio_msg_on"]  | true;
+    _settings.audioAnnounceEnabled = doc["audio_announce_on"]  | true;
+    _settings.audioErrorEnabled = doc["audio_error_on"]  | true;
     _settings.audioVolume  = doc["audio_vol"] | 80;
 
     _settings.displayName = doc["display_name"] | "";
@@ -112,7 +115,9 @@ String UserConfig::serializeToJson() const {
     doc["tz_set"]       = _settings.timezoneSet;
     doc["time_24h"]     = _settings.use24HourTime;
 
-    doc["audio_on"]  = _settings.audioEnabled;
+    doc["audio_boot_on"]  = _settings.audioBootEnabled;
+    doc["audio_msg_on"]  = _settings.audioMsgEnabled;
+    doc["audio_announce_on"]  = _settings.audioAnnounceEnabled;
     doc["audio_vol"] = _settings.audioVolume;
 
     doc["display_name"] = _settings.displayName;

--- a/src/config/UserConfig.h
+++ b/src/config/UserConfig.h
@@ -59,7 +59,10 @@ struct UserSettings {
     bool use24HourTime = false;      // false = 12h (no AM/PM), true = 24h
 
     // Audio
-    bool audioEnabled = true;
+    bool audioBootEnabled = true;
+    bool audioMsgEnabled = true;
+    bool audioAnnounceEnabled = true;
+    bool audioErrorEnabled = true;
     uint8_t audioVolume = 80;  // 0-100
 
     // Identity

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -518,6 +518,7 @@ void setup() {
     // (LVGL boot renders via lv_timer_handler in setProgress)
     announceManager = new AnnounceManager();
     announceManager->setStorage(&sdStore, &flash);
+    announceManager->setAudio(&audio);
     announceManager->setLocalDestHash(rns.destination().hash());
     if (rns.loraInterface()) announceManager->setLoRaInterface(rns.loraInterface());
     announceManager->loadContacts();
@@ -669,7 +670,10 @@ void setup() {
     // Step 25: Audio init
     lvBootScreen.setProgress(0.94f, "Audio...");
     // (LVGL boot renders via lv_timer_handler in setProgress)
-    audio.setEnabled(userConfig.settings().audioEnabled);
+    audio.setBootEnabled(userConfig.settings().audioBootEnabled);
+    audio.setMsgEnabled(userConfig.settings().audioMsgEnabled);
+    audio.setAnnounceEnabled(userConfig.settings().audioAnnounceEnabled);
+    audio.setErrorEnabled(userConfig.settings().audioErrorEnabled);
     audio.setVolume(userConfig.settings().audioVolume);
     audio.begin();
 

--- a/src/reticulum/AnnounceManager.cpp
+++ b/src/reticulum/AnnounceManager.cpp
@@ -4,6 +4,7 @@
 #include "storage/SDStore.h"
 #include "storage/FlashStore.h"
 #include "transport/LoRaInterface.h"
+#include "audio/AudioNotify.h"
 #include <ArduinoJson.h>
 #include <LittleFS.h>
 
@@ -98,6 +99,7 @@ AnnounceManager::AnnounceManager(const char* aspectFilter) : RNS::AnnounceHandle
 }
 
 void AnnounceManager::setStorage(SDStore* sd, FlashStore* flash) { _sd = sd; _flash = flash; }
+void AnnounceManager::setAudio(AudioNotify* audio) { _audio = audio; }
 
 void AnnounceManager::received_announce(
     const RNS::Bytes& destination_hash,
@@ -142,6 +144,7 @@ void AnnounceManager::received_announce(
         if (++_globalAnnounceCount > MAX_GLOBAL_ANNOUNCES_PER_SEC) return;
     }
 
+
     std::string key = makeKey(destination_hash);
     std::string idHex = announced_identity ? announced_identity.hexhash() : "";
 
@@ -167,8 +170,11 @@ void AnnounceManager::received_announce(
                 _nameCacheDirty = true;
             }
         }
+        _audio->playAnnounce(true);
         return;
     }
+
+    _audio->playAnnounce(false);
 
     // New node — toHex needed for log + name cache
     std::string destHex = destination_hash.toHex();

--- a/src/reticulum/AnnounceManager.h
+++ b/src/reticulum/AnnounceManager.h
@@ -11,6 +11,7 @@
 class SDStore;
 class FlashStore;
 class LoRaInterface;
+class AudioNotify;
 
 struct DiscoveredNode {
     RNS::Bytes hash;
@@ -34,6 +35,7 @@ public:
         const RNS::Bytes& app_data) override;
 
     void setStorage(SDStore* sd, FlashStore* flash);
+    void setAudio(AudioNotify* audio);
     void setLoRaInterface(LoRaInterface* li) { _loraIf = li; }
     void setLocalDestHash(const RNS::Bytes& hash) { _localDestHash = hash; }
     void saveContacts();
@@ -62,6 +64,7 @@ private:
 
     std::vector<DiscoveredNode> _nodes;
     SDStore* _sd = nullptr;
+    AudioNotify* _audio = nullptr;
     FlashStore* _flash = nullptr;
     LoRaInterface* _loraIf = nullptr;
     RNS::Bytes _localDestHash;

--- a/src/ui/screens/LvSettingsScreen.cpp
+++ b/src/ui/screens/LvSettingsScreen.cpp
@@ -452,9 +452,24 @@ void LvSettingsScreen::buildItems() {
 
     // Audio
     int audioStart = idx;
-    _items.push_back({"Audio", SettingType::TOGGLE,
-        [&s]() { return s.audioEnabled ? 1 : 0; },
-        [&s](int v) { s.audioEnabled = (v != 0); },
+    _items.push_back({"Boot", SettingType::TOGGLE,
+        [&s]() { return s.audioBootEnabled ? 1 : 0; },
+        [&s](int v) { s.audioBootEnabled = (v != 0); },
+        [](int v) { return v ? String("ON") : String("OFF"); }});
+    idx++;
+    _items.push_back({"Messages", SettingType::TOGGLE,
+        [&s]() { return s.audioMsgEnabled ? 1 : 0; },
+        [&s](int v) { s.audioMsgEnabled = (v != 0); },
+        [](int v) { return v ? String("ON") : String("OFF"); }});
+    idx++;
+    _items.push_back({"Announces", SettingType::TOGGLE,
+        [&s]() { return s.audioAnnounceEnabled ? 1 : 0; },
+        [&s](int v) { s.audioAnnounceEnabled = (v != 0); },
+        [](int v) { return v ? String("ON") : String("OFF"); }});
+    idx++;
+    _items.push_back({"Errors", SettingType::TOGGLE,
+        [&s]() { return s.audioErrorEnabled ? 1 : 0; },
+        [&s](int v) { s.audioErrorEnabled = (v != 0); },
         [](int v) { return v ? String("ON") : String("OFF"); }});
     idx++;
     _items.push_back({"Volume", SettingType::INTEGER,
@@ -462,7 +477,7 @@ void LvSettingsScreen::buildItems() {
         [](int v) { return String(v) + "%"; }, 0, 100, 10});
     idx++;
     _categories.push_back({"Audio", audioStart, idx - audioStart,
-        [&s]() { return s.audioEnabled ? (String(s.audioVolume) + "%") : String("OFF"); }});
+        [&s]() { return s.audioBootEnabled || s.audioMsgEnabled || s.audioAnnounceEnabled || s.audioErrorEnabled ? (String(s.audioVolume) + "%") : String("OFF"); }});
 
     // Info (diagnostics moved from Home screen)
     int infoStart = idx;
@@ -1345,7 +1360,10 @@ void LvSettingsScreen::applyAndSave() {
         _radio->receive();
     }
     if (_audio) {
-        _audio->setEnabled(s.audioEnabled);
+        _audio->setBootEnabled(s.audioBootEnabled);
+        _audio->setMsgEnabled(s.audioMsgEnabled);
+        _audio->setAnnounceEnabled(s.audioAnnounceEnabled);
+        _audio->setErrorEnabled(s.audioErrorEnabled);
         _audio->setVolume(s.audioVolume);
     }
 


### PR DESCRIPTION
I've implemented separate settings for audio notifications; for example, sometimes you want to mute the sound after boot. I've also added a notification for announcements. I've included the ability to create separate announcement notifications for new and existing ones.

In the future, I want to implement the ability to specify custom sounds via external sound files on the SD card. If the files are present, they play; if not, the built-in system sounds are used.