### PR TITLE
Fix contacts and conversations vanishing on reboot

### DIFF
--- a/src/config/Config.h
+++ b/src/config/Config.h
@@ -30,14 +30,17 @@
 #define PATH_IDENTITY_BAK   "/identity/identity.key.bak"
 #define PATH_PATHS          "/transport/paths.msgpack"
 #define PATH_USER_CONFIG    "/config/user.json"
-#define PATH_CONTACTS       "/contacts/"
-#define PATH_MESSAGES       "/messages/"
+// Directory paths intentionally have NO trailing slash — some FATFS/VFS
+// readdir paths fail to enumerate when given a path ending in '/'.
+// Concat sites must add their own '/' before the basename.
+#define PATH_CONTACTS       "/contacts"
+#define PATH_MESSAGES       "/messages"
 
 // --- SD Card Paths ---
 #define SD_PATH_CONFIG_DIR   "/ratdeck/config"
 #define SD_PATH_USER_CONFIG  "/ratdeck/config/user.json"
-#define SD_PATH_MESSAGES     "/ratdeck/messages/"
-#define SD_PATH_CONTACTS     "/ratdeck/contacts/"
+#define SD_PATH_MESSAGES     "/ratdeck/messages"
+#define SD_PATH_CONTACTS     "/ratdeck/contacts"
 #define SD_PATH_IDENTITY     "/ratdeck/identity/identity.key"
 
 // --- TCP Client ---

--- a/src/reticulum/AnnounceManager.cpp
+++ b/src/reticulum/AnnounceManager.cpp
@@ -349,15 +349,15 @@ void AnnounceManager::saveContact(const DiscoveredNode& node) {
     serializeJson(doc, json);
     String filename = hexHash.substr(0, 16).c_str();
     filename += ".json";
-    if (_sd && _sd->isReady()) { _sd->writeString((String(SD_PATH_CONTACTS) + filename).c_str(), json); }
-    if (_flash) { _flash->writeString((String(PATH_CONTACTS) + filename).c_str(), json); }
+    if (_sd && _sd->isReady()) { _sd->writeString((String(SD_PATH_CONTACTS) + "/" + filename).c_str(), json); }
+    if (_flash) { _flash->writeString((String(PATH_CONTACTS) + "/" + filename).c_str(), json); }
 }
 
 void AnnounceManager::removeContact(const std::string& hexHash) {
     String filename = hexHash.substr(0, 16).c_str();
     filename += ".json";
-    if (_sd && _sd->isReady()) { _sd->remove((String(SD_PATH_CONTACTS) + filename).c_str()); }
-    if (_flash) { _flash->remove((String(PATH_CONTACTS) + filename).c_str()); }
+    if (_sd && _sd->isReady()) { _sd->remove((String(SD_PATH_CONTACTS) + "/" + filename).c_str()); }
+    if (_flash) { _flash->remove((String(PATH_CONTACTS) + "/" + filename).c_str()); }
 }
 
 bool AnnounceManager::deleteContact(int nodeIdx) {

--- a/src/storage/MessageStore.cpp
+++ b/src/storage/MessageStore.cpp
@@ -146,7 +146,7 @@ void MessageStore::migrateTruncatedDirs() {
                 // Old dirs are exactly 16 hex chars; new ones are 32
                 if (dirName.length() == 16) {
                     // Read first JSON file inside to get the full hash
-                    String oldDir = String(basePath) + dirName.c_str();
+                    String oldDir = String(basePath) + "/" + dirName.c_str();
                     File inner = openFn(oldDir.c_str());
                     if (inner && inner.isDirectory()) {
                         File jsonFile = inner.openNextFile();
@@ -176,7 +176,7 @@ void MessageStore::migrateTruncatedDirs() {
                         inner.close();
 
                         if (!fullHash.empty() && fullHash.substr(0, 16) == dirName) {
-                            String newDir = String(basePath) + fullHash.c_str();
+                            String newDir = String(basePath) + "/" + fullHash.c_str();
                             renames.push_back({oldDir, newDir});
                         }
                     }
@@ -738,11 +738,11 @@ int MessageStore::totalUnreadCount() const {
 }
 
 String MessageStore::conversationDir(const std::string& peerHex) const {
-    return String(PATH_MESSAGES) + peerHex.c_str();
+    return String(PATH_MESSAGES) + "/" + peerHex.c_str();
 }
 
 String MessageStore::sdConversationDir(const std::string& peerHex) const {
-    return String(SD_PATH_MESSAGES) + peerHex.c_str();
+    return String(SD_PATH_MESSAGES) + "/" + peerHex.c_str();
 }
 
 void MessageStore::enforceFlashLimit(const std::string& peerHex) {


### PR DESCRIPTION
Manually-added contacts and existing conversations disappeared from the UI after every reboot, while settings, identity, and the name cache survived. Files were intact on the SD card and in flash, but `loadContacts()` and `MessageStore::refreshConversations()` enumerated 0 entries.

## Root cause

`PATH_CONTACTS`, `PATH_MESSAGES`, `SD_PATH_CONTACTS` and `SD_PATH_MESSAGES` (`src/config/Config.h`) all ended in `/`. The FATFS layer used by both Arduino-ESP32's `SD` and `LittleFS` returns a valid handle from `opendir("/some/dir/")` but `readdir` then yields nothing — so the directory iteration loops in `AnnounceManager::loadContacts` and `MessageStore::refreshConversations` exited immediately with empty results.

Direct reads via known paths (`SD.open("/ratdeck/config/user.json", FILE_READ)`) never hit `readdir`, which is why settings/identity/names cache persisted but anything that relied on enumerating a directory was lost.

## Fix

Drop the trailing `/` from all four constants and add an explicit `/` at the concat sites: `saveContact`, `removeContact`, `conversationDir`, `sdConversationDir`, and the `migrateTruncatedDirs` path builders. No on-disk layout change — existing data is unaffected.