### PR TITLE
AnnounceManager: stop doubling peers and dropping name characters

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -522,7 +522,9 @@ void setup() {
     // Step 18: Announce manager
     lvBootScreen.setProgress(0.78f, "Loading contacts...");
     // (LVGL boot renders via lv_timer_handler in setProgress)
-    announceManager = new AnnounceManager();
+    // Filter to lxmf.delivery so we don't capture every aspect (lxmf.propagation,
+    // nomadnetwork.node, etc.) from the same peer as separate "doubled" entries.
+    announceManager = new AnnounceManager("lxmf.delivery");
     announceManager->setStorage(&sdStore, &flash);
     announceManager->setLocalDestHash(rns.destination().hash());
     if (rns.loraInterface()) announceManager->setLoRaInterface(rns.loraInterface());

--- a/src/reticulum/AnnounceManager.cpp
+++ b/src/reticulum/AnnounceManager.cpp
@@ -82,7 +82,7 @@ static std::string sanitizeName(const std::string& raw, size_t maxLen = 16) {
     for (char c : raw) {
         if (clean.size() >= maxLen) break;
         if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
-            (c >= '0' && c <= '9') || c == ' ' || c == '-' || c == '_' || c == '.' || c == '\'') {
+            (c >= '0' && c <= '9') || c == ' ' || c == '-' || c == '_' || c == '.' || c == '\'' || c == '/') {
             clean += c;
         }
     }


### PR DESCRIPTION
Two small AnnounceManager fixes that together make the peer list match what Sideband / Columba and other LXMF clients actually announce.

## Commits

### 1. `sanitizeName: allow forward slash in display names`

`sanitizeName()` (`src/reticulum/AnnounceManager.cpp`) allowlisted only `A-Z`, `a-z`, `0-9`, space, `-`, `_`, `.` and `'`. Sideband/Columba and other LXMF clients commonly include `/` in display names (handle/path conventions). The strip was mangling `alice/columba` into `alicecolumba`. Saved contacts get re-sanitized on every load, so existing names also lose the slash on next boot.

Fix: add `/` to the allowlist.

### 2. `AnnounceManager: filter to lxmf.delivery aspect`

The `AnnounceHandler` was constructed with no aspect filter, so it captured every announce of every aspect from every peer (`lxmf.delivery`, `lxmf.propagation`, `nomadnetwork.node`, …). Each aspect has a different destination hash, so the same Sideband/Columba peer appeared multiple times in the nodes list — once with the display name (`lxmf.delivery`'s app_data carries it) and once or more as raw hex (other aspects had no/different name).

Fix: construct the handler with `"lxmf.delivery"` filter. That's the only destination we ever route LXMF messages to. Propagation/NomadNet visibility could come back later behind an opt-in toggle if needed.

## Migration note

Existing saved contacts captured under non-`lxmf.delivery` aspects will still appear after this change since they're loaded from disk. They can be removed manually via the contacts UI.