### PR TITLE
Power: manual screen-off + pocket-carry input gating

### DIFF
--- a/src/hal/Power.cpp
+++ b/src/hal/Power.cpp
@@ -48,9 +48,20 @@ uint8_t Power::percentToPWM(uint8_t pct) const {
 
 void Power::activity() {
     _lastActivity = millis();
+    if (_state == SCREEN_OFF) {
+        _justWokeFromOff = true;
+    }
     if (_state != ACTIVE) {
         setState(ACTIVE);
     }
+}
+
+void Power::forceScreenOff() {
+    if (_justWokeFromOff) {
+        _justWokeFromOff = false;
+        return;
+    }
+    setState(SCREEN_OFF);
 }
 
 void Power::weakActivity() {
@@ -96,6 +107,8 @@ void Power::loop() {
         case SCREEN_OFF:
             break;
     }
+
+    _justWokeFromOff = false;
 }
 
 void Power::setState(State newState) {

--- a/src/hal/Power.h
+++ b/src/hal/Power.h
@@ -15,6 +15,9 @@ public:
     void activity();
     // Weak activity = trackball — wakes from DIM only, not SCREEN_OFF
     void weakActivity();
+    // Manual screen-off; no-op if activity() just woke from SCREEN_OFF this tick
+    // so a single keypress can't both wake and re-sleep.
+    void forceScreenOff();
 
     // Battery
     float batteryVoltage() const;
@@ -57,4 +60,5 @@ private:
     static constexpr uint8_t DIM_PWM = 40;  // ~15% PWM when dimmed
     bool _kbAutoOn = false;
     bool _kbAutoOff = false;
+    bool _justWokeFromOff = false;
 };

--- a/src/input/InputManager.cpp
+++ b/src/input/InputManager.cpp
@@ -31,8 +31,11 @@ void InputManager::update() {
             _activity = true;  // Movement is weak — only wakes from dim
         }
 
-        // Generate nav events from trackball movement (click handled below via GPIO)
-        if (!_hasKey) {
+        // Generate nav events from trackball movement (click handled below via GPIO).
+        // Skip entirely when screen is off so a backpacked device doesn't accumulate
+        // phantom up/down/left/right keypresses or wake from movement.
+        bool screenOn = !_powerMgr || _powerMgr->isScreenOn();
+        if (!_hasKey && screenOn) {
             unsigned long now = millis();
 
             // Accumulate deltas, clamp to ±20

--- a/src/input/InputManager.cpp
+++ b/src/input/InputManager.cpp
@@ -85,11 +85,16 @@ void InputManager::update() {
                 _clickPending = true;
                 _longPressFired = false;
                 _clickStartMs = millis();
+                // Capture screen state BEFORE activity wakes it, so long-press
+                // doesn't blank a freshly-woken screen (wake-then-blank ping-pong)
+                _clickFromScreenOn = _powerMgr ? _powerMgr->isScreenOn() : true;
                 _activity = true;
                 _strongActivity = true;  // Click wakes from screen off
             } else if (!_longPressFired && millis() - _clickStartMs >= LONG_PRESS_MS) {
-                // Long press threshold reached
-                _longPress = true;
+                // Long press threshold reached — only emit if click started screen-on
+                if (_clickFromScreenOn) {
+                    _longPress = true;
+                }
                 _longPressFired = true;
                 _hasKey = false;  // Suppress any concurrent events
                 _activity = true;
@@ -117,8 +122,10 @@ void InputManager::update() {
         }
     }
 
-    // Touch activity check — throttled to ~50Hz
-    if (_touch) {
+    // Touch activity check — throttled to ~50Hz.
+    // Suppressed while screen is off (pocket-carry safety: prevents
+    // accidental wakes from pressure on the touch panel).
+    if (_touch && (!_powerMgr || _powerMgr->isScreenOn())) {
         unsigned long now = millis();
         if (now - _lastTouchPoll >= TOUCH_POLL_MS) {
             _lastTouchPoll = now;

--- a/src/input/InputManager.h
+++ b/src/input/InputManager.h
@@ -3,10 +3,12 @@
 #include "hal/Keyboard.h"
 #include "hal/Trackball.h"
 #include "hal/TouchInput.h"
+#include "hal/Power.h"
 
 class InputManager {
 public:
     void begin(Keyboard* kb, Trackball* tb, TouchInput* touch);
+    void setPowerMgr(Power* pm) { _powerMgr = pm; }
     void update();
 
     // Keyboard events
@@ -26,6 +28,7 @@ private:
     Keyboard* _kb = nullptr;
     Trackball* _tb = nullptr;
     TouchInput* _touch = nullptr;
+    Power* _powerMgr = nullptr;
 
     bool _hasKey = false;
     KeyEvent _keyEvent;
@@ -34,6 +37,7 @@ private:
     bool _longPress = false;
     bool _clickPending = false;
     bool _longPressFired = false;
+    bool _clickFromScreenOn = true;  // Captured at click DOWN to gate long-press
     unsigned long _clickStartMs = 0;
     unsigned long _lastClickDownMs = 0;
     static constexpr unsigned long LONG_PRESS_MS = 1200;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -435,6 +435,7 @@ void setup() {
 
     // Step 10: Input manager
     inputManager.begin(&keyboard, &trackball, &touch);
+    inputManager.setPowerMgr(&powerMgr);
 
     // Step 10.5: LVGL input drivers
     LvInput::init(&keyboard, &trackball, &touch);
@@ -933,9 +934,11 @@ void loop() {
         powerMgr.weakActivity();   // Trackball: wake from dim only
     }
 
-    // 2. Long-press dispatch
+    // 2. Long-press dispatch — screen blanking is the default if no screen consumes it
     if (inputManager.hadLongPress()) {
-        ui.handleLongPress();
+        if (!ui.handleLongPress()) {
+            powerMgr.forceScreenOff();
+        }
     }
 
     // 3. Key event dispatch


### PR DESCRIPTION
Three related changes that let the user intentionally blank the screen and prevent accidental wakes when the device is in a pocket or backpack.

## Commits

### 1. `Add Power::forceScreenOff() for manual screen-off triggers`

New public `Power::forceScreenOff()` that transitions to `SCREEN_OFF` on demand, plus a `_justWokeFromOff` flag set in `activity()` and cleared at the end of `loop()` so a single keypress that woke the screen can't immediately re-blank it via a hotkey/long-press handler running in the same tick.

Pure infrastructure — no UI binding included; consumers wire it to whatever input event fits.

### 2. `Long-press trackball blanks screen; suppress touch wakes when off`

Two pocket-carry quality-of-life additions:

1. Long-press (1.2s) of the trackball click blanks the screen if no LVGL screen consumes the long-press first. `InputManager` captures the power state at click DOWN (`_clickFromScreenOn`) and only emits `_longPress` if the screen was already on, so a long-press from `SCREEN_OFF` wakes without immediately re-blanking.
2. Touch events are ignored entirely while screen is off, preventing accidental wakes from pressure on the panel in a pocket/bag. Trackball click and keyboard keys still wake normally.

`InputManager` now holds a `Power*` injected via `setPowerMgr()` in setup.

### 3. `Suppress trackball nav events while screen is off`

Trackball deltas crossing the nav threshold previously fired up/down/left/right key events AND set `_strongActivity = true`, which woke the screen from `SCREEN_OFF` on any pocket/backpack jostle and also accumulated phantom navigation in the UI behind the dark screen.

Gate the nav-event block on `isScreenOn()`, mirroring the touch suppression. Click/long-press detection stays unconditional so an intentional trackball press still wakes the device.

## What still wakes from SCREEN_OFF

- Keyboard keypress (intentional, expected)
- Trackball click / long-press (intentional, expected)

## What no longer wakes

- Touch panel pressure
- Trackball jostle / drift movement