### PR TITLE
Fix wake-click and long-press blanking from subscreens

### DIFF
--- a/src/input/InputManager.cpp
+++ b/src/input/InputManager.cpp
@@ -107,8 +107,9 @@ void InputManager::update() {
             // GPIO is HIGH — only accept release after debounce period
             if (millis() - _lastClickDownMs >= CLICK_DEBOUNCE_MS) {
                 _clickPending = false;
-                if (!_longPressFired && !_hasKey) {
-                    // Short click — generate deferred enter event
+                // Suppress wake-click: if the press began with the screen off,
+                // the click's job was just to wake the device, not to confirm.
+                if (!_longPressFired && !_hasKey && _clickFromScreenOn) {
                     _keyEvent = {};
                     _keyEvent.enter = true;
                     _keyEvent.character = '\n';

--- a/src/ui/screens/LvContactsScreen.cpp
+++ b/src/ui/screens/LvContactsScreen.cpp
@@ -119,6 +119,9 @@ void LvContactsScreen::rebuildList() {
 
 bool LvContactsScreen::handleLongPress() {
     if (!_am || _contactIndices.empty()) return false;
+    // Only consume long-press once the user has actively navigated into
+    // the list. Otherwise let main.cpp blank the screen.
+    if (!_focusActive) return false;
     lv_obj_t* focused = lv_group_get_focused(LvInput::group());
     if (!focused) return false;
     _deleteIdx = (int)(intptr_t)lv_obj_get_user_data(focused);

--- a/src/ui/screens/LvMessagesScreen.cpp
+++ b/src/ui/screens/LvMessagesScreen.cpp
@@ -185,6 +185,9 @@ int LvMessagesScreen::getFocusedPeerIdx() const {
 
 bool LvMessagesScreen::handleLongPress() {
     if (!_lxmf) return false;
+    // Only consume long-press once the user has actively navigated into
+    // the list. Otherwise let main.cpp blank the screen.
+    if (!_focusActive) return false;
     int idx = getFocusedPeerIdx();
     if (idx < 0 || idx >= (int)_sortedPeers.size()) return false;
     _lpPeerIdx = idx;

--- a/src/ui/screens/LvNodesScreen.cpp
+++ b/src/ui/screens/LvNodesScreen.cpp
@@ -324,6 +324,9 @@ void LvNodesScreen::updateNicknameDisplay() {
 
 bool LvNodesScreen::handleLongPress() {
     if (!_am) return false;
+    // Only consume long-press once the user has actively navigated into
+    // the list. Otherwise let main.cpp blank the screen.
+    if (!_focusActive) return false;
     int nodeIdx = getFocusedNodeIdx();
     if (nodeIdx < 0 || nodeIdx >= (int)_am->nodes().size()) return false;
     const auto& node = _am->nodes()[nodeIdx];


### PR DESCRIPTION
Follow-up to #32. Two usability issues surfaced in the beta after the
pocket-safe wake changes landed:

- Trackball click that wakes the screen also fired as enter, triggering
  whatever was focused. Short-click emit is now gated on the same
  `_clickFromScreenOn` flag the long-press path already used.
- Long-press to blank only worked from Home. Contacts / Messages / Peers
  consumed long-press as soon as LVGL had any focused row, opening a
  delete dialog instead. Each `handleLongPress` now early-returns false
  unless `_focusActive` is true (user has actively navigated in with
  up/down/enter). Resting on a tab falls through to `forceScreenOff()`,
  same as Home.

Beta-only regression, no migration concerns.