### PR TITLE
Fix message timestamps clipping out of bubble

### DIFF
--- a/src/ui/screens/LvMessageView.cpp
+++ b/src/ui/screens/LvMessageView.cpp
@@ -196,10 +196,14 @@ void LvMessageView::appendMessage(const LXMFMessage& msg) {
     const lv_font_t* font = &lv_font_ratdeck_12;
     int maxBubbleW = Theme::CONTENT_W * 3 / 4;
 
-    // Bubble container
+    // Bubble container. Reserve pad_bottom for the timestamp row so the
+    // bubble's allocated height in the flex scroll includes it — without
+    // this, the time renders into the row gap and looks like it's hanging
+    // outside the bubble.
     lv_obj_t* bubble = lv_obj_create(_msgScroll);
     lv_obj_set_width(bubble, Theme::CONTENT_W - 12);
     lv_obj_set_style_pad_all(bubble, 0, 0);
+    lv_obj_set_style_pad_bottom(bubble, 14, 0);
     lv_obj_set_style_bg_opa(bubble, LV_OPA_TRANSP, 0);
     lv_obj_set_style_border_width(bubble, 0, 0);
     lv_obj_clear_flag(bubble, LV_OBJ_FLAG_SCROLLABLE);
@@ -216,10 +220,10 @@ void LvMessageView::appendMessage(const LXMFMessage& msg) {
 
     if (msg.incoming) {
         lv_obj_set_style_bg_color(box, lv_color_hex(Theme::MSG_IN_BG), 0);
-        lv_obj_align(box, LV_ALIGN_LEFT_MID, 0, 0);
+        lv_obj_align(box, LV_ALIGN_TOP_LEFT, 0, 0);
     } else {
         lv_obj_set_style_bg_color(box, lv_color_hex(Theme::MSG_OUT_BG), 0);
-        lv_obj_align(box, LV_ALIGN_RIGHT_MID, 0, 0);
+        lv_obj_align(box, LV_ALIGN_TOP_RIGHT, 0, 0);
     }
     lv_obj_set_style_bg_opa(box, LV_OPA_COVER, 0);
 


### PR DESCRIPTION
In `LvMessageView`, the timestamp label is positioned below the message
box via `lv_obj_align_to(... OUT_BOTTOM_LEFT/RIGHT)`. The bubble container
used `LV_SIZE_CONTENT` height with `pad_all=0`, so its allocated row in
the flex scroll was just the box's height - the timestamp rendered into
the 6px row gap and looked like it was hanging outside the bubble.

Reserve `pad_bottom = 14` on the bubble so its outer height covers the
timestamp row, and anchor the box at `TOP_LEFT`/`TOP_RIGHT` (was
`LEFT_MID`/`RIGHT_MID`) for clean top-to-bottom stacking.