### PR TITLE
FlashStore: fall back to "spiffs" partition label for M5Launcher

### DIFF
--- a/src/storage/FlashStore.cpp
+++ b/src/storage/FlashStore.cpp
@@ -1,15 +1,20 @@
 #include "FlashStore.h"
 
 bool FlashStore::begin() {
-    // Partition label must match partitions_16MB.csv ("littlefs")
-    // Arduino ESP32 LittleFS defaults to "spiffs" label, so we must specify it
-    if (!LittleFS.begin(true, "/littlefs", 10, "littlefs")) {
-        Serial.println("[FLASH] LittleFS mount failed, formatting...");
-        LittleFS.format();
-        if (!LittleFS.begin(false, "/littlefs", 10, "littlefs")) {
-            Serial.println("[FLASH] LittleFS failed after format!");
-            return false;
+    // Standalone ratdeck labels this partition "littlefs"; bmorcelli/Launcher
+    // labels the equivalent partition "spiffs". Try ours first, fall back.
+    const char* labels[] = { "littlefs", "spiffs" };
+    bool mounted = false;
+    for (const char* label : labels) {
+        if (LittleFS.begin(true, "/littlefs", 10, label)) {
+            Serial.printf("[FLASH] LittleFS mounted on partition '%s'\n", label);
+            mounted = true;
+            break;
         }
+    }
+    if (!mounted) {
+        Serial.println("[FLASH] LittleFS mount failed on all known labels!");
+        return false;
     }
     _ready = true;
 


### PR DESCRIPTION
[M5Launcher](https://github.com/bmorcelli/Launcher) labels its user-app data partition `spiffs`; standalone
ratdeck uses `littlefs`. The partition subtype is identical in both
layouts, only the label differs.

Try `littlefs` first, then fall back to `spiffs`, so a ratdeck build
flashed on top of an M5Launcher install works correctly instead of
failing with OOM errors because of failing mount.