### PR TITLE
Multi-network STA: phone-style WiFi with WiFiMulti

### DIFF
--- a/src/config/UserConfig.cpp
+++ b/src/config/UserConfig.cpp
@@ -28,8 +28,24 @@ bool UserConfig::parseJson(const String& json) {
     }
     _settings.wifiAPSSID     = doc["wifi_ap_ssid"]     | "";
     _settings.wifiAPPassword = doc["wifi_ap_pass"]     | WIFI_AP_PASSWORD;
-    _settings.wifiSTASSID    = doc["wifi_sta_ssid"]    | "";
-    _settings.wifiSTAPassword = doc["wifi_sta_pass"]   | "";
+
+    // Migrate from legacy wifi_sta_ssid/wifi_sta_pass when array is absent.
+    _settings.wifiSTANetworks.clear();
+    JsonArray staArr = doc["wifi_sta_networks"];
+    if (staArr) {
+        for (JsonObject obj : staArr) {
+            if (_settings.wifiSTANetworks.size() >= WIFI_STA_MAX_NETWORKS) break;
+            WiFiNetwork n;
+            n.ssid = obj["ssid"] | "";
+            n.password = obj["pass"] | "";
+            if (!n.ssid.isEmpty()) _settings.wifiSTANetworks.push_back(n);
+        }
+    } else {
+        WiFiNetwork legacy;
+        legacy.ssid = doc["wifi_sta_ssid"] | "";
+        legacy.password = doc["wifi_sta_pass"] | "";
+        if (!legacy.ssid.isEmpty()) _settings.wifiSTANetworks.push_back(legacy);
+    }
 
     // AutoInterface (LAN auto-discovery)
     _settings.autoIfaceEnabled  = doc["autoiface_en"]    | false;
@@ -95,8 +111,14 @@ String UserConfig::serializeToJson() const {
     doc["wifi_mode"] = (int)_settings.wifiMode;
     doc["wifi_ap_ssid"] = _settings.wifiAPSSID;
     doc["wifi_ap_pass"] = _settings.wifiAPPassword;
-    doc["wifi_sta_ssid"] = _settings.wifiSTASSID;
-    doc["wifi_sta_pass"] = _settings.wifiSTAPassword;
+
+    JsonArray staArr = doc["wifi_sta_networks"].to<JsonArray>();
+    for (auto& n : _settings.wifiSTANetworks) {
+        if (n.ssid.isEmpty()) continue;
+        JsonObject obj = staArr.add<JsonObject>();
+        obj["ssid"] = n.ssid;
+        obj["pass"] = n.password;
+    }
 
     doc["autoiface_en"]    = _settings.autoIfaceEnabled;
     doc["autoiface_group"] = _settings.autoIfaceGroupId;

--- a/src/config/UserConfig.h
+++ b/src/config/UserConfig.h
@@ -10,6 +10,13 @@
 
 enum RatWiFiMode : uint8_t { RAT_WIFI_OFF = 0, RAT_WIFI_AP = 1, RAT_WIFI_STA = 2 };
 
+struct WiFiNetwork {
+    String ssid;
+    String password;
+};
+
+constexpr size_t WIFI_STA_MAX_NETWORKS = 3;
+
 struct TCPEndpoint {
     String host;
     uint16_t port = TCP_DEFAULT_PORT;
@@ -30,8 +37,8 @@ struct UserSettings {
     RatWiFiMode wifiMode = RAT_WIFI_STA;
     String wifiAPSSID;
     String wifiAPPassword = WIFI_AP_PASSWORD;
-    String wifiSTASSID;
-    String wifiSTAPassword;
+
+    std::vector<WiFiNetwork> wifiSTANetworks;
 
     // AutoInterface (Reticulum LAN auto-discovery via IPv6 multicast).
     // Active only in STA mode; opt-in until proven stable on real APs.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -46,6 +46,7 @@
 #include "reticulum/IdentityManager.h"
 #include "transport/LoRaInterface.h"
 #include "transport/WiFiInterface.h"
+#include <WiFiMulti.h>
 #include "transport/TCPClientInterface.h"
 #include "transport/BLEInterface.h"
 #include "transport/AutoInterfaceWrapper.h"
@@ -122,6 +123,7 @@ bool radioOnline = false;
 bool bootComplete = false;
 bool bootLoopRecovery = false;
 bool wifiSTAStarted = false;
+WiFiMulti wifiMulti;
 bool wifiSTAConnected = false;
 unsigned long lastAutoAnnounce = 0;
 
@@ -667,20 +669,26 @@ void setup() {
         ui.lvStatusBar().setWiFiActive(true);
     } else if (wifiMode == RAT_WIFI_STA) {
         lvBootScreen.setProgress(0.87f, "WiFi STA starting...");
-        // WiFi is enabled but not yet connected — indicator will be yellow
-        if (!userConfig.settings().wifiSTASSID.isEmpty()) {
+        auto& nets = userConfig.settings().wifiSTANetworks;
+        int registered = 0;
+        for (auto& n : nets) {
+            if (n.ssid.isEmpty()) continue;
+            wifiMulti.addAP(n.ssid.c_str(), n.password.c_str());
+            registered++;
+        }
+        if (registered > 0) {
             WiFi.mode(WIFI_STA);
+            // Drive reconnects from onWiFiEvent + main loop with backoff.
             WiFi.onEvent(onWiFiEvent);
-            // AutoInterface needs an IPv6 link-local address.  Must be enabled
-            // BEFORE WiFi.begin() so SLAAC starts on STA association.
+            // AutoInterface needs an IPv6 link-local address. Must be enabled
+            // before the first association so SLAAC starts in time.
             if (userConfig.settings().autoIfaceEnabled) {
                 WiFi.enableIpV6();
                 Serial.println("[WIFI] IPv6 enabled (AutoInterface ON)");
             }
-            WiFi.begin(userConfig.settings().wifiSTASSID.c_str(),
-                       userConfig.settings().wifiSTAPassword.c_str());
+            wifiMulti.run(5000);
             wifiSTAStarted = true;
-            Serial.printf("[WIFI] STA: %s\n", userConfig.settings().wifiSTASSID.c_str());
+            Serial.printf("[WIFI] STA: %d saved network(s) registered\n", registered);
         }
     } else {
         lvBootScreen.setProgress(0.87f, "WiFi disabled");
@@ -1085,8 +1093,7 @@ void loop() {
             (long)(millis() - wifiReconnectAt) >= 0) {
             wifiNeedsReconnect = false;
             Serial.printf("[WIFI] Reconnect attempt #%u\n", (unsigned)wifiReconnectAttempt);
-            WiFi.begin(userConfig.settings().wifiSTASSID.c_str(),
-                       userConfig.settings().wifiSTAPassword.c_str());
+            wifiMulti.run(2000);
         }
         bool connected = (WiFi.status() == WL_CONNECTED);
         if (connected && !wifiSTAConnected) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -54,6 +54,7 @@
 #include "audio/AudioNotify.h"
 #include <ArduinoJson.h>
 #include <Preferences.h>
+#include <atomic>
 #include <list>
 #include <esp_system.h>
 #include <freertos/task.h>
@@ -123,6 +124,32 @@ bool bootLoopRecovery = false;
 bool wifiSTAStarted = false;
 bool wifiSTAConnected = false;
 unsigned long lastAutoAnnounce = 0;
+
+// STA reconnect: scheduled by onWiFiEvent, fired by loop().
+std::atomic<bool> wifiNeedsReconnect{false};
+std::atomic<unsigned long> wifiReconnectAt{0};
+std::atomic<uint8_t> wifiReconnectAttempt{0};
+constexpr unsigned long WIFI_BACKOFF_MS[4] = {5000, 15000, 60000, 300000};
+
+static void onWiFiEvent(WiFiEvent_t event) {
+    switch (event) {
+        case ARDUINO_EVENT_WIFI_STA_DISCONNECTED: {
+            uint8_t attempt = wifiReconnectAttempt;
+            uint8_t idx = attempt < 4 ? attempt : 3;
+            wifiReconnectAt = millis() + WIFI_BACKOFF_MS[idx];
+            wifiNeedsReconnect = true;
+            if (attempt < 4) wifiReconnectAttempt = attempt + 1;
+            break;
+        }
+        case ARDUINO_EVENT_WIFI_STA_GOT_IP:
+        case ARDUINO_EVENT_WIFI_STA_GOT_IP6:
+            wifiNeedsReconnect = false;
+            wifiReconnectAttempt = 0;
+            break;
+        default:
+            break;
+    }
+}
 unsigned long lastStatusUpdate = 0;
 constexpr unsigned long STATUS_UPDATE_MS = 1000;                // 1 Hz status bar update
 unsigned long lastHeartbeat = 0;
@@ -634,7 +661,7 @@ void setup() {
         // WiFi is enabled but not yet connected — indicator will be yellow
         if (!userConfig.settings().wifiSTASSID.isEmpty()) {
             WiFi.mode(WIFI_STA);
-            WiFi.setAutoReconnect(true);
+            WiFi.onEvent(onWiFiEvent);
             // AutoInterface needs an IPv6 link-local address.  Must be enabled
             // BEFORE WiFi.begin() so SLAAC starts on STA association.
             if (userConfig.settings().autoIfaceEnabled) {
@@ -1045,6 +1072,13 @@ void loop() {
 
     // 7. WiFi STA connection handler
     if (wifiSTAStarted) {
+        if (wifiNeedsReconnect && WiFi.status() != WL_CONNECTED &&
+            (long)(millis() - wifiReconnectAt) >= 0) {
+            wifiNeedsReconnect = false;
+            Serial.printf("[WIFI] Reconnect attempt #%u\n", (unsigned)wifiReconnectAttempt);
+            WiFi.begin(userConfig.settings().wifiSTASSID.c_str(),
+                       userConfig.settings().wifiSTAPassword.c_str());
+        }
         bool connected = (WiFi.status() == WL_CONNECTED);
         if (connected && !wifiSTAConnected) {
             wifiSTAConnected = true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -130,13 +130,22 @@ std::atomic<bool> wifiNeedsReconnect{false};
 std::atomic<unsigned long> wifiReconnectAt{0};
 std::atomic<uint8_t> wifiReconnectAttempt{0};
 constexpr unsigned long WIFI_BACKOFF_MS[4] = {5000, 15000, 60000, 300000};
+// Floor on the next begin() so lwIP can unwind the netif first.
+constexpr unsigned long WIFI_NETIF_SETTLE_MS = 1500;
 
 static void onWiFiEvent(WiFiEvent_t event) {
     switch (event) {
         case ARDUINO_EVENT_WIFI_STA_DISCONNECTED: {
+            // Our own disconnect() below generates another STA_DISCONNECTED;
+            // ignore it so the deadline doesn't get pushed to the backoff cap.
+            if (wifiNeedsReconnect) break;
+            // Drop the netif and clear stale AP info before the next begin().
+            WiFi.disconnect(false, true);
             uint8_t attempt = wifiReconnectAttempt;
             uint8_t idx = attempt < 4 ? attempt : 3;
-            wifiReconnectAt = millis() + WIFI_BACKOFF_MS[idx];
+            unsigned long backoff = WIFI_BACKOFF_MS[idx];
+            if (backoff < WIFI_NETIF_SETTLE_MS) backoff = WIFI_NETIF_SETTLE_MS;
+            wifiReconnectAt = millis() + backoff;
             wifiNeedsReconnect = true;
             if (attempt < 4) wifiReconnectAttempt = attempt + 1;
             break;

--- a/src/ui/screens/LvSettingsScreen.cpp
+++ b/src/ui/screens/LvSettingsScreen.cpp
@@ -353,22 +353,40 @@ void LvSettingsScreen::buildItems() {
         [&s](int v) { s.wifiMode = (RatWiFiMode)v; },
         nullptr, 0, 2, 1, {"OFF", "AP", "STA"}});
     idx++;
-    {
+    // Static label storage — SettingItem holds const char*, so the buffers
+    // must outlive each buildItems() call.
+    static char ssidLbls[WIFI_STA_MAX_NETWORKS][24];
+    static char passLbls[WIFI_STA_MAX_NETWORKS][28];
+    for (size_t slot = 0; slot < WIFI_STA_MAX_NETWORKS; slot++) {
+        snprintf(ssidLbls[slot], sizeof(ssidLbls[slot]), "WiFi %u SSID", (unsigned)(slot + 1));
+        snprintf(passLbls[slot], sizeof(passLbls[slot]), "WiFi %u Password", (unsigned)(slot + 1));
+
         SettingItem ssidItem;
-        ssidItem.label = "WiFi SSID";
+        ssidItem.label = ssidLbls[slot];
         ssidItem.type = SettingType::TEXT_INPUT;
-        ssidItem.textGetter = [&s]() { return s.wifiSTASSID; };
-        ssidItem.textSetter = [&s](const String& v) { s.wifiSTASSID = v; };
+        ssidItem.textGetter = [&s, slot]() {
+            return slot < s.wifiSTANetworks.size() ? s.wifiSTANetworks[slot].ssid : String("");
+        };
+        ssidItem.textSetter = [&s, slot](const String& v) {
+            // Don't compact mid-edit: keep slot positions stable while the
+            // user is filling fields. Empty entries get filtered on serialize.
+            while (s.wifiSTANetworks.size() <= slot) s.wifiSTANetworks.push_back({});
+            s.wifiSTANetworks[slot].ssid = v;
+        };
         ssidItem.maxTextLen = 32;
         _items.push_back(ssidItem);
         idx++;
-    }
-    {
+
         SettingItem passItem;
-        passItem.label = "WiFi Password";
+        passItem.label = passLbls[slot];
         passItem.type = SettingType::TEXT_INPUT;
-        passItem.textGetter = [&s]() { return s.wifiSTAPassword; };
-        passItem.textSetter = [&s](const String& v) { s.wifiSTAPassword = v; };
+        passItem.textGetter = [&s, slot]() {
+            return slot < s.wifiSTANetworks.size() ? s.wifiSTANetworks[slot].password : String("");
+        };
+        passItem.textSetter = [&s, slot](const String& v) {
+            while (s.wifiSTANetworks.size() <= slot) s.wifiSTANetworks.push_back({});
+            s.wifiSTANetworks[slot].password = v;
+        };
         passItem.maxTextLen = 32;
         _items.push_back(passItem);
         idx++;
@@ -1013,7 +1031,24 @@ void LvSettingsScreen::rebuildWifiList() {
             int idx = (int)(intptr_t)lv_obj_get_user_data(lv_event_get_target(e));
             if (idx < (int)self->_wifiResults.size()) {
                 auto& net = self->_wifiResults[idx];
-                if (self->_cfg) { self->_cfg->settings().wifiSTASSID = net.ssid; self->applyAndSave(); }
+                if (self->_cfg) {
+                    auto& nets = self->_cfg->settings().wifiSTANetworks;
+                    bool dup = false;
+                    for (auto& n : nets) { if (!n.ssid.isEmpty() && n.ssid == net.ssid) { dup = true; break; } }
+                    if (dup) {
+                        if (self->_ui) self->_ui->lvStatusBar().showToast("Already saved", 1200);
+                    } else {
+                        bool placed = false;
+                        for (auto& n : nets) {
+                            if (n.ssid.isEmpty()) { n.ssid = net.ssid; n.password = ""; placed = true; break; }
+                        }
+                        if (!placed && nets.size() < WIFI_STA_MAX_NETWORKS) {
+                            WiFiNetwork w; w.ssid = net.ssid; nets.push_back(w); placed = true;
+                        }
+                        if (placed) self->applyAndSave();
+                        else if (self->_ui) self->_ui->lvStatusBar().showToast("Network slots full", 1500);
+                    }
+                }
             }
             self->_view = SettingsView::ITEM_LIST;
             self->rebuildItemList();
@@ -1319,7 +1354,24 @@ bool LvSettingsScreen::handleKey(const KeyEvent& event) {
                     int idx = (int)(intptr_t)lv_obj_get_user_data(focused);
                     if (idx < (int)_wifiResults.size()) {
                         auto& net = _wifiResults[idx];
-                        if (_cfg) { _cfg->settings().wifiSTASSID = net.ssid; applyAndSave(); }
+                        if (_cfg) {
+                            auto& nets = _cfg->settings().wifiSTANetworks;
+                            bool dup = false;
+                            for (auto& n : nets) { if (!n.ssid.isEmpty() && n.ssid == net.ssid) { dup = true; break; } }
+                            if (dup) {
+                                if (_ui) _ui->lvStatusBar().showToast("Already saved", 1200);
+                            } else {
+                                bool placed = false;
+                                for (auto& n : nets) {
+                                    if (n.ssid.isEmpty()) { n.ssid = net.ssid; n.password = ""; placed = true; break; }
+                                }
+                                if (!placed && nets.size() < WIFI_STA_MAX_NETWORKS) {
+                                    WiFiNetwork w; w.ssid = net.ssid; nets.push_back(w); placed = true;
+                                }
+                                if (placed) applyAndSave();
+                                else if (_ui) _ui->lvStatusBar().showToast("Network slots full", 1500);
+                            }
+                        }
                     }
                 }
                 _view = SettingsView::ITEM_LIST;
@@ -1341,8 +1393,7 @@ void LvSettingsScreen::snapshotRebootSettings() {
     if (!_cfg) return;
     auto& s = _cfg->settings();
     _rebootSnap.wifiMode = s.wifiMode;
-    _rebootSnap.wifiSTASSID = s.wifiSTASSID;
-    _rebootSnap.wifiSTAPassword = s.wifiSTAPassword;
+    _rebootSnap.wifiSTANetworks = s.wifiSTANetworks;
     _rebootSnap.bleEnabled = s.bleEnabled;
     _rebootSnap.autoIfaceEnabled = s.autoIfaceEnabled;
     _gpsSnapEnabled = s.gpsTimeEnabled;
@@ -1351,11 +1402,15 @@ void LvSettingsScreen::snapshotRebootSettings() {
 bool LvSettingsScreen::rebootSettingsChanged() const {
     if (!_cfg) return false;
     auto& s = _cfg->settings();
-    return s.wifiMode != _rebootSnap.wifiMode
-        || s.wifiSTASSID != _rebootSnap.wifiSTASSID
-        || s.wifiSTAPassword != _rebootSnap.wifiSTAPassword
-        || s.bleEnabled != _rebootSnap.bleEnabled
-        || s.autoIfaceEnabled != _rebootSnap.autoIfaceEnabled;
+    if (s.wifiMode != _rebootSnap.wifiMode) return true;
+    if (s.bleEnabled != _rebootSnap.bleEnabled) return true;
+    if (s.autoIfaceEnabled != _rebootSnap.autoIfaceEnabled) return true;
+    if (s.wifiSTANetworks.size() != _rebootSnap.wifiSTANetworks.size()) return true;
+    for (size_t i = 0; i < s.wifiSTANetworks.size(); i++) {
+        if (s.wifiSTANetworks[i].ssid != _rebootSnap.wifiSTANetworks[i].ssid) return true;
+        if (s.wifiSTANetworks[i].password != _rebootSnap.wifiSTANetworks[i].password) return true;
+    }
+    return false;
 }
 
 void LvSettingsScreen::snapshotTCPSettings() {

--- a/src/ui/screens/LvSettingsScreen.h
+++ b/src/ui/screens/LvSettingsScreen.h
@@ -152,8 +152,7 @@ private:
     bool _rebootNeeded = false;
     struct RebootSnapshot {
         RatWiFiMode wifiMode;
-        String wifiSTASSID;
-        String wifiSTAPassword;
+        std::vector<WiFiNetwork> wifiSTANetworks;
         bool bleEnabled;
         bool autoIfaceEnabled;
     };


### PR DESCRIPTION
Replaces the single `wifiSTASSID/wifiSTAPassword` pair with a list of
saved networks (cap 3) backed by `WiFiMulti`. Settings shows three
SSID/password pairs; scan-pick appends with dedup; one-shot migration
on load preserves existing single-network configs.

stability fix split out as #41, please merge that first; this rebases cleanly on top