### PR TITLE
Add ability to import identity from SD card

### DIFF
--- a/src/config/Config.h
+++ b/src/config/Config.h
@@ -42,6 +42,7 @@
 #define SD_PATH_MESSAGES     "/ratdeck/messages"
 #define SD_PATH_CONTACTS     "/ratdeck/contacts"
 #define SD_PATH_IDENTITY     "/ratdeck/identity/identity.key"
+#define SD_PATH_IMPORT_ID    "/ratdeck/identity/import.key"
 
 // --- TCP Client ---
 #define MAX_TCP_CONNECTIONS         4

--- a/src/reticulum/IdentityManager.cpp
+++ b/src/reticulum/IdentityManager.cpp
@@ -45,6 +45,35 @@ String IdentityManager::slotKeyPath(int slotNum) const {
     return String(path);
 }
 
+int IdentityManager::importIdentity(const String& displayName) {
+    if ((int)_slots.size() >= MAX_IDENTITIES) return -1;
+
+    // Generate new identity
+    RNS::Identity newId;
+    uint8_t buffer[64];
+    size_t bytesRead;
+    bool isReadOk = _sd->readFile("/ratdeck/identity/import.key", buffer, 64, bytesRead);
+    if (!isReadOk || bytesRead < 64) return -1;
+    RNS::Bytes privKey = RNS::Bytes(buffer, 64);
+
+    int slotNum = (int)_slots.size();
+    String keyPath = slotKeyPath(slotNum);
+
+    // Save key file
+    _flash->writeAtomic(keyPath.c_str(), privKey.data(), privKey.size());
+
+    IdentitySlot slot;
+    slot.hash = newId.hexhash();
+    slot.displayName = "";  // New identity starts unnamed
+    slot.keyPath = keyPath;
+    slot.active = false;
+    _slots.push_back(slot);
+
+    saveSlotMeta();
+    Serial.printf("[IDMGR] Created identity %d: %s\n", slotNum, slot.hash.substr(0, 16).c_str());
+    return slotNum;
+}
+
 int IdentityManager::createIdentity(const String& displayName) {
     if ((int)_slots.size() >= MAX_IDENTITIES) return -1;
 

--- a/src/reticulum/IdentityManager.h
+++ b/src/reticulum/IdentityManager.h
@@ -25,6 +25,9 @@ public:
     // Current active identity index (-1 if none)
     int activeIndex() const { return _activeIdx; }
 
+    // Import identity from SD card
+    int importIdentity(const String& displayName = "");
+    
     // Create a new identity, returns index
     int createIdentity(const String& displayName = "");
 

--- a/src/ui/screens/LvSettingsScreen.cpp
+++ b/src/ui/screens/LvSettingsScreen.cpp
@@ -177,6 +177,25 @@ void LvSettingsScreen::buildItems() {
         _items.push_back(newId);
         idx++;
     }
+    if (_sd && _sd->isReady()) {
+        SettingItem importId;
+        importId.label = "Import Identity";
+        importId.type = SettingType::ACTION;
+        importId.formatter = [](int) { return String("[Enter]"); };
+        importId.action = [this, &s]() {
+            if (!_sd->exists(SD_PATH_IMPORT_ID)) { if (_ui) _ui->lvStatusBar().showToast("Place identity file on SD card!", 1200); return; }
+            if (!_idMgr) { if (_ui) _ui->lvStatusBar().showToast("Not available", 1200); return; }
+            if (_idMgr->count() >= 8) { if (_ui) _ui->lvStatusBar().showToast("Max 8 identities!", 1200); return; }
+            int idx = _idMgr->importIdentity(s.displayName);
+            if (idx >= 0) {
+                if (_ui) _ui->lvStatusBar().showToast("Identity created!", 1200);
+                buildItems();
+                rebuildCategoryList();
+            }
+        };
+        _items.push_back(importId);
+        idx++;
+    }
     _items.push_back({"Announce Interval", SettingType::INTEGER,
         [&s]() { return s.announceInterval; }, [&s](int v) { s.announceInterval = v; },
         [](int v) { return String(v) + "m"; }, 5, 60 * 6, 5}); // 5m - 6h

--- a/src/ui/screens/LvSettingsScreen.cpp
+++ b/src/ui/screens/LvSettingsScreen.cpp
@@ -192,6 +192,9 @@ void LvSettingsScreen::buildItems() {
                 buildItems();
                 rebuildCategoryList();
             }
+            else {
+                if (_ui) _ui->lvStatusBar().showToast("Identity import failed!", 1200);
+            }
         };
         _items.push_back(importId);
         idx++;


### PR DESCRIPTION
What I was missing in ratdeck, was that I was able to create my vanity identity key with prefix/postfix of my choosing, but ratdeck didn't allow me to use it, only ones generated by ratdeck.

This PR adds new menu item below `New identity` that shows on the list when SD card is inserted.
Menu item is labelled `Import identity`. After pressing `Enter` it loads the file `/ratdeck/identity/import.key` and if it is 64 bytes it creates new identity using keys from this file.