### PR TITLE
Settings: show full LXMF address and identity hash

### DIFF
--- a/src/ui/screens/LvSettingsScreen.cpp
+++ b/src/ui/screens/LvSettingsScreen.cpp
@@ -96,10 +96,10 @@ void LvSettingsScreen::buildItems() {
         [](int) { return String(RATDECK_VERSION_STRING); }});
     idx++;
     _items.push_back({"LXMF Addr", SettingType::READONLY, nullptr, nullptr,
-        [this](int) { return _destinationHash.length() > 0 ? _destinationHash.substring(0, 16) : String("unknown"); }});
+        [this](int) { return _destinationHash.length() > 0 ? _destinationHash : String("unknown"); }});
     idx++;
     _items.push_back({"Identity", SettingType::READONLY, nullptr, nullptr,
-        [this](int) { return _identityHash.substring(0, 16); }});
+        [this](int) { return _identityHash; }});
     idx++;
     {
         SettingItem nameItem;


### PR DESCRIPTION
Both the LXMF Addr and Identity readonly entries truncated to the first 16 hex chars, which made it impossible to type or read the real address into another client (Sideband, Columba, etc) for adding ratdeck as a contact. Drop the substring(0, 16) calls and show the full 32-char hex.