### PR TITLE
TCPClientInterface: async connect + safe stop() during WiFi loss

### DIFF
--- a/src/transport/TCPClientInterface.cpp
+++ b/src/transport/TCPClientInterface.cpp
@@ -1,6 +1,8 @@
 #include "TCPClientInterface.h"
 #include "config/Config.h"
 
+#include <WiFi.h>
+
 TCPClientInterface::TCPClientInterface(const char* host, uint16_t port, const char* name)
     : RNS::InterfaceImpl(name), _host(host), _port(port)
 {
@@ -31,9 +33,9 @@ bool TCPClientInterface::start() {
 
 void TCPClientInterface::stop() {
     _online = false;
-    // If a connect attempt is in flight, wait for it before tearing down
-    // _client — the task is the only thread allowed to touch _client during
-    // CS_CONNECTING.
+    // WiFi down: don't wait for the connect task — it's blocked on a dead
+    // netif and busy-waiting risks TWDT + lwIP panic. The task self-cleans.
+    if (WiFi.status() != WL_CONNECTED) return;
     waitForConnectTask();
     if (_client.connected()) {
         _client.stop();

--- a/src/transport/TCPClientInterface.cpp
+++ b/src/transport/TCPClientInterface.cpp
@@ -31,17 +31,50 @@ bool TCPClientInterface::start() {
 
 void TCPClientInterface::stop() {
     _online = false;
+    // If a connect attempt is in flight, wait for it before tearing down
+    // _client — the task is the only thread allowed to touch _client during
+    // CS_CONNECTING.
+    waitForConnectTask();
     if (_client.connected()) {
         _client.stop();
         Serial.printf("[TCP] Disconnected from %s:%d\n", _host.c_str(), _port);
     }
 }
 
-void TCPClientInterface::tryConnect() {
-    _lastAttempt = millis();
-    Serial.printf("[TCP] Connecting to %s:%d...\n", _host.c_str(), _port);
+void TCPClientInterface::waitForConnectTask() {
+    while (_connectState == CS_CONNECTING) {
+        vTaskDelay(pdMS_TO_TICKS(20));
+    }
+    // Task self-deletes; clear the handle once we've observed it finish.
+    _connectTask = nullptr;
+}
 
-    if (_client.connect(_host.c_str(), _port, TCP_CONNECT_TIMEOUT_MS)) {
+void TCPClientInterface::connectTaskFn(void* arg) {
+    auto* self = static_cast<TCPClientInterface*>(arg);
+    bool ok = self->_client.connect(self->_host.c_str(), self->_port, TCP_CONNECT_TIMEOUT_MS);
+    self->_connectState = ok ? CS_CONNECTED : CS_FAILED;
+    vTaskDelete(NULL);
+}
+
+void TCPClientInterface::tryConnect() {
+    if (_connectState == CS_CONNECTING) return;
+    _lastAttempt = millis();
+    _connectState = CS_CONNECTING;
+    Serial.printf("[TCP] Connecting to %s:%d (async)...\n", _host.c_str(), _port);
+    BaseType_t ok = xTaskCreate(connectTaskFn, "tcpconn", 4096, this, 1, &_connectTask);
+    if (ok != pdPASS) {
+        _connectState = CS_IDLE;
+        Serial.printf("[TCP] Failed to spawn connect task for %s:%d\n", _host.c_str(), _port);
+    }
+}
+
+void TCPClientInterface::loop() {
+    if (!_online) return;
+
+    // Claim async connect results
+    if (_connectState == CS_CONNECTED) {
+        _connectState = CS_IDLE;
+        _connectTask = nullptr;
         // Reset HDLC frame state and hub discovery for new connection
         _inFrame = false;
         _escaped = false;
@@ -55,13 +88,15 @@ void TCPClientInterface::tryConnect() {
         _client.setNoDelay(true);  // Disable Nagle — send immediately
 
         Serial.printf("[TCP] Connected to %s:%d\n", _host.c_str(), _port);
-    } else {
+    } else if (_connectState == CS_FAILED) {
+        _connectState = CS_IDLE;
+        _connectTask = nullptr;
         Serial.printf("[TCP] Failed to connect to %s:%d\n", _host.c_str(), _port);
     }
-}
 
-void TCPClientInterface::loop() {
-    if (!_online) return;
+    // While the connect task is running, the main loop must not touch
+    // _client (Arduino's WiFiClient is not safe for concurrent access).
+    if (_connectState == CS_CONNECTING) return;
 
     // Auto-reconnect (only if WiFi is connected)
     if (!_client.connected()) {
@@ -127,6 +162,11 @@ void TCPClientInterface::loop() {
 void TCPClientInterface::send_outgoing(const RNS::Bytes& data) {
     if (!_online) {
         Serial.printf("[TCP] TX BLOCKED (offline) %d bytes to %s:%d\n", (int)data.size(), _host.c_str(), _port);
+        return;
+    }
+    // _client is owned by the connect task while CS_CONNECTING — don't touch it
+    if (_connectState == CS_CONNECTING) {
+        Serial.printf("[TCP] TX BLOCKED (connecting) %d bytes to %s:%d\n", (int)data.size(), _host.c_str(), _port);
         return;
     }
     if (!_client.connected()) {

--- a/src/transport/TCPClientInterface.h
+++ b/src/transport/TCPClientInterface.h
@@ -4,6 +4,8 @@
 #include <WiFi.h>
 #include <WiFiClient.h>
 #include <vector>
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
 
 class TCPClientInterface : public RNS::InterfaceImpl {
 public:
@@ -18,7 +20,10 @@ public:
         return "TCPClient[" + _name + "]";
     }
 
-    bool isConnected() { return _client.connected(); }
+    bool isConnected() {
+        if (_connectState == CS_CONNECTING) return false;
+        return _client.connected();
+    }
     const String& host() const { return _host; }
     uint16_t port() const { return _port; }
 
@@ -29,6 +34,18 @@ private:
     void tryConnect();
     void sendFrame(const uint8_t* data, size_t len);
     int readFrame();
+    static void connectTaskFn(void* arg);
+    void waitForConnectTask();
+
+    // _client.connect() blocks; run it in a one-shot task and observe via _connectState.
+    enum ConnectState : uint8_t {
+        CS_IDLE       = 0,
+        CS_CONNECTING = 1,
+        CS_CONNECTED  = 2,  // task done, main loop must claim
+        CS_FAILED     = 3,  // task done, main loop must claim
+    };
+    volatile ConnectState _connectState = CS_IDLE;
+    TaskHandle_t _connectTask = nullptr;
 
     WiFiClient _client;
     String _host;


### PR DESCRIPTION
- `WiFiClient::connect()` is fully synchronous (DNS + 3-way handshake) and
  blocks for up to `TCP_CONNECT_TIMEOUT_MS` (5s). Every reconnect attempt
  to an unreachable hub stalled the main loop and froze LVGL for the full
  window. Move the connect into a one-shot FreeRTOS task; the loop claims
  the result on the next tick.
- `stop()` previously busy-waited for any in-flight connect task. When
  WiFi went down mid-connect, the task was blocked inside lwIP on a dead
  netif - the wait could trip TWDT and the IDF could panic inside the
  blocking call. Now `stop()` returns immediately if WiFi is down; the
  task fails on the dead socket and self-cleans on the next CS_FAILED
  check.

Pairs thematically with #41 - both harden the
disassociate teardown path - but is independent. Either can land first.