### PR TITLE
Boot: bring backlight up after first boot-screen frame

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -440,6 +440,11 @@ void setup() {
     ui.lvStatusBar().setLoRaOnline(radioOnline);
     lvBootScreen.setProgress(0.45f, radioOnline ? "Radio online" : "Radio FAILED");
 
+    // Display::begin() left the backlight at 0 to hide an unpainted
+    // framebuffer; the setProgress() above has now flushed the boot screen.
+    // powerMgr at step 24 overrides with the user's configured value.
+    display.setBrightness(128);
+
     // Step 7: Touch HAL — GT911 I2C
     touch.begin();
     lvBootScreen.setProgress(0.50f, "Touch ready");


### PR DESCRIPTION
`037af2a` ("Brightness adjustments") had `Display::begin()` set the
backlight to 0 at startup so the user never sees an un-painted
framebuffer, deferring it to `powerMgr.setBrightness()` at step 24
of `setup()`. Step 24 is the very last thing before boot completes —
the entire 24-step boot sequence rendered into a dark panel and the
home screen only popped in at the end.

Restore a fixed mid-range backlight (PWM 128, ~50%) immediately after
the first `lvBootScreen.setProgress()` call. By then LVGL has flushed
the boot screen to the panel, so there's no garbage to expose.
`powerMgr.setBrightness()` at step 24 still overrides this with the
user's configured value once `UserConfig` has loaded.