### PR TITLE
ui: bypass LVGL frame throttle on input activity

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1282,11 +1282,14 @@ void loop() {
         }
     }
 
-    // 3. LVGL timer handler — 30 FPS active, 5 FPS dimmed
+    // 3. LVGL timer handler — 30 FPS active, 5 FPS dimmed.
+    // Bypass the throttle on input activity so a keypress/scroll renders this
+    // iteration instead of waiting up to a full frame interval.
     {
         unsigned long now = millis();
         unsigned long lvglInterval = powerMgr.isDimmed() ? 200 : LVGL_INTERVAL_MS;
-        if (powerMgr.isScreenOn() && now - lastLvglTime >= lvglInterval) {
+        bool inputBurst = inputManager.hadActivity();
+        if (powerMgr.isScreenOn() && (inputBurst || now - lastLvglTime >= lvglInterval)) {
             lastLvglTime = now;
             lv_timer_handler();
         }


### PR DESCRIPTION
Input events otherwise wait up to a full 33ms frame interval before LVGL renders, which is noticeable when the loop body is loaded. When the input poll reports activity, run lv_timer_handler() immediately and let the next idle frame fall back to the 30 FPS cadence.