### PR TITLE
Smoothing battery level & adjusting battery font size

### DIFF
--- a/src/ui/LvStatusBar.cpp
+++ b/src/ui/LvStatusBar.cpp
@@ -177,7 +177,10 @@ void LvStatusBar::setGPSFix(bool hasFix) {
 
 void LvStatusBar::setBatteryPercent(int pct) {
     pct = normalizedBattery(pct);
-    if (_battPct == pct) return;
+
+    // Suppress single-percent ADC noise: only update if the value changed by 2% or more
+    if (_battPct >= 0 && abs(pct - _battPct) < 2) return;
+
     _battPct = pct;
     refreshBattery();
 }

--- a/src/ui/LvStatusBar.cpp
+++ b/src/ui/LvStatusBar.cpp
@@ -49,7 +49,7 @@ void LvStatusBar::create(lv_obj_t* parent) {
     // Right: battery percentage.
     _lblBatt = lv_label_create(_bar);
     lv_obj_set_size(_lblBatt, kBattW, Theme::STATUS_BAR_H);
-    lv_obj_set_style_text_font(_lblBatt, &lv_font_ratdeck_10, 0);
+    lv_obj_set_style_text_font(_lblBatt, &lv_font_ratdeck_12, 0);
     lv_obj_set_style_text_align(_lblBatt, LV_TEXT_ALIGN_RIGHT, 0);
     lv_label_set_long_mode(_lblBatt, LV_LABEL_LONG_CLIP);
     lv_obj_align(_lblBatt, LV_ALIGN_RIGHT_MID, -4, 0);


### PR DESCRIPTION
This PR smoothes battery level caused by ADC noise. It's checking if there is a change greater than 2% of battery level. This reduces flattering of battery level. There might be more precise changes like averaging battery level, but this one is a first, very simple, approach. 

Also font size of battery level has been increased from `lv_font_ratdeck_10` to `lv_font_ratdeck_12` so its size is consistent with clock. 

