### PR TITLE
switched peers box to LORA AIRTIME

### DIFF
--- a/src/ui/screens/LvHomeScreen.cpp
+++ b/src/ui/screens/LvHomeScreen.cpp
@@ -207,11 +207,32 @@ void LvHomeScreen::createUI(lv_obj_t* parent) {
         self->toggleWiFi();
     }, this);
 
-    _statNodes = makeStat(parent, kPad, "PEERS", &_lblNodes);
-    makeClickable(_statNodes, [](lv_event_t* e) {
-        auto* self = (LvHomeScreen*)lv_event_get_user_data(e);
-        self->openPeers();
-    }, this);
+    _statNodes = makePanel(parent, kPad, kStatY, kCellW, kStatH, Theme::BG_ELEVATED, Theme::BORDER);
+    makeCaption(_statNodes, "LORA AIRTIME");
+    _rssiChart = lv_chart_create(_statNodes);
+    lv_obj_set_pos(_rssiChart, 4, 15);
+    lv_obj_set_size(_rssiChart, 90, 20);
+    lv_obj_set_style_bg_opa(_rssiChart, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(_rssiChart, 0, 0);
+    lv_obj_set_style_pad_all(_rssiChart, 0, 0);
+    lv_obj_clear_flag(_rssiChart, LV_OBJ_FLAG_SCROLLABLE | LV_OBJ_FLAG_CLICKABLE);
+    lv_chart_set_type(_rssiChart, LV_CHART_TYPE_BAR);
+    lv_chart_set_point_count(_rssiChart, kRssiPoints);
+    lv_chart_set_div_line_count(_rssiChart, 0, 0);
+    lv_obj_set_style_pad_column(_rssiChart, 0, LV_PART_MAIN);
+    lv_chart_set_range(_rssiChart, LV_CHART_AXIS_PRIMARY_Y, -130, 0);
+    lv_chart_set_range(_rssiChart, LV_CHART_AXIS_SECONDARY_Y, 0, 100);
+    _rssiSeries = lv_chart_add_series(_rssiChart, lv_color_hex(Theme::SUCCESS), LV_CHART_AXIS_PRIMARY_Y);
+    _txSeries = lv_chart_add_series(_rssiChart, lv_color_hex(Theme::WARNING_CLR), LV_CHART_AXIS_SECONDARY_Y);
+    lv_chart_set_all_value(_rssiChart, _rssiSeries, LV_CHART_POINT_NONE);
+    lv_chart_set_all_value(_rssiChart, _txSeries, LV_CHART_POINT_NONE);
+    int oldest = (_rssiHistoryNext - _rssiHistoryCount + kRssiPoints) % kRssiPoints;
+    for (int i = 0; i < _rssiHistoryCount; i++) {
+        const auto& sample = _rssiHistory[(oldest + i) % kRssiPoints];
+        lv_chart_set_next_value(_rssiChart, _rssiSeries, sample.first);
+        lv_chart_set_next_value(_rssiChart, _txSeries, sample.second);
+    }
+
     _statPaths = makeStat(parent, kPad + kCellW + kGap, "AUDIO", &_lblPaths);
     makeClickable(_statPaths, [](lv_event_t* e) {
         auto* self = (LvHomeScreen*)lv_event_get_user_data(e);
@@ -356,11 +377,28 @@ void LvHomeScreen::refreshUI() {
     if (_am) {
         online = _am->nodesOnlineSince(1800000);
     }
-    lv_label_set_text_fmt(_lblNodes, "%d", online);
-    lv_obj_set_style_text_color(_lblNodes, lv_color_hex(
-        online > 0 ? Theme::ACCENT : Theme::TEXT_SECONDARY), 0);
     setPanelTone(_statNodes, online > 0 ? Theme::PRIMARY_SUBTLE : Theme::BG_ELEVATED,
                  online > 0 ? Theme::PRIMARY : Theme::BORDER);
+    // LORA AIRTIME
+    // Fills RSSI values and TX values to _rssiHistory
+    {
+        int16_t rssiVal = LV_CHART_POINT_NONE;
+        int16_t txVal = LV_CHART_POINT_NONE;
+        if (_radio && _radio->isTxBusy()) {
+            txVal = 100;
+        } else if (_radio) {
+            rssiVal = (int16_t)_radio->currentRssi();
+        }
+
+        _rssiHistory[_rssiHistoryNext] = {rssiVal, txVal};
+        _rssiHistoryNext = (_rssiHistoryNext + 1) % kRssiPoints;
+        if (_rssiHistoryCount < kRssiPoints) _rssiHistoryCount++;
+
+        if (_rssiChart && _rssiSeries && _txSeries) {
+            lv_chart_set_next_value(_rssiChart, _rssiSeries, rssiVal);
+            lv_chart_set_next_value(_rssiChart, _txSeries, txVal);
+        }
+    }
 
     bool audioOn = !_cfg || _cfg->settings().audioEnabled;
     lv_label_set_text(_lblPaths, audioOn ? "ON" : "OFF");
@@ -430,10 +468,6 @@ bool LvHomeScreen::handleKey(const KeyEvent& event) {
         }
         if (focused == _statLinks) {
             toggleGPS();
-            return true;
-        }
-        if (focused == _statNodes) {
-            openPeers();
             return true;
         }
         if (_announceCb) _announceCb();

--- a/src/ui/screens/LvHomeScreen.h
+++ b/src/ui/screens/LvHomeScreen.h
@@ -4,6 +4,8 @@
 #include <Arduino.h>
 #include <functional>
 #include <vector>
+#include <utility>
+#include <array>
 
 class ReticulumManager;
 class SX1262;
@@ -66,6 +68,14 @@ private:
     lv_obj_t* _statNodes = nullptr;
     lv_obj_t* _statPaths = nullptr;
     lv_obj_t* _statLinks = nullptr;
+    lv_obj_t* _rssiChart = nullptr;
+    lv_chart_series_t* _rssiSeries = nullptr;
+    lv_chart_series_t* _txSeries = nullptr;
+
+    static constexpr int kRssiPoints = 30;
+    std::array<std::pair<int16_t, int16_t>, kRssiPoints> _rssiHistory{};  // {rssi-or-NONE, tx-or-NONE}
+    int _rssiHistoryNext = 0;   // index the next sample will be written to
+    int _rssiHistoryCount = 0;  // number of valid samples so far (caps at kRssiPoints)
 
     lv_obj_t* _lblConsoleTitle = nullptr;
     lv_obj_t* _lblName = nullptr;


### PR DESCRIPTION
This PR drops the "Total Peers" Box and adds a "LORA AIRTIME" Chart, which displays RSSI levels and displays TX states so it's easier debugging, what's LoRa actually doing. Green is the actual RSSI Level, Orange is the state of active sending a burst

Note: "Total Peers": In my opinion this is a doubled value/box - most recent Peers might be of biggest interest, all other peers can be viewed in Peers tab.

<img width="3024" height="4032" alt="IMG_0172" src="https://github.com/user-attachments/assets/4870e2a2-e279-41d0-9388-4486d61adc22" />
